### PR TITLE
updates for current clj cli

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+.cpcache
+target
+resources/public/js/

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 To start Figwheel, open `src/cljs/myapp/core.cljs` in Emacs and type <b>`C-c C-x j s`</b>
 
-Or start from a terminal by typing <b>`clj -A:figwheel`</b>
+Or start from a terminal by typing <b>`clj -M:figwheel`</b>
 
-For production run <b>`clj -A:prod`</b>
+For production run <b>`clj -M:prod`</b> then open the `resources/public/index.html` file in a browser to run.

--- a/deps.edn
+++ b/deps.edn
@@ -2,12 +2,12 @@
  
  :deps {org.clojure/clojure {:mvn/version "1.10.1"}
         org.clojure/clojurescript {:mvn/version "1.10.773"}
-        reagent {:mvn/version "1.0.0"}}
+        reagent/reagent {:mvn/version "1.0.0"}}
 
  
  :aliases
  {:prod
-  {:main-opts ["-m cljs.main -co prod.cljs.edn -c myapp.core"]}
+  {:main-opts ["-m" "cljs.main" "-co" "prod.cljs.edn" "-c" "myapp.core"]}
 
 
   :cider
@@ -18,4 +18,4 @@
   :figwheel
   {:extra-paths ["resources"]
    :extra-deps {com.bhauman/figwheel-main {:mvn/version "0.2.12"}}
-   :main-opts ["-m figwheel.main -b dev -r"]}}}
+   :main-opts ["-m" "figwheel.main" "-b" "dev" "-r"]}}}


### PR DESCRIPTION
- Splits :main-opts into individual vector entries
- Changes README to use `-M`
- Changes README to say how to open prod build
- Add generated files to .gitignore